### PR TITLE
Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data/compile.log
 data/crate-information.json
 data/crates
 *.swp
+.idea

--- a/rustql-extractor/src/main.rs
+++ b/rustql-extractor/src/main.rs
@@ -91,7 +91,6 @@ impl rustc_driver::Callbacks for Callbacks {
                 let mut cv = CrateVisitor {
                     crate_data: data::Crate::new(&crate_name, crate_version, &config_hash),
                     current_function: None,
-                    // crate_name: crate_name,
                     map: hir_map,
                     tcx: tcx,
                     local_modules: BTreeMap::new(),

--- a/rustql-extractor/src/visitor.rs
+++ b/rustql-extractor/src/visitor.rs
@@ -51,7 +51,6 @@ impl<'tcx, 'a> CrateVisitor<'tcx, 'a> {
                     _ => data::Type::Other,
                 }
             }
-            /*hir::TyKind::Ptr(ty) |*/
             hir::TyKind::Rptr(_, ty) => data::Type::Reference {
                 to: box self.create_type(&ty.ty),
                 is_mutable: ty.mutbl == hir::Mutability::MutMutable,
@@ -216,21 +215,6 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
             _ => {}
         }
 
-        /*
-        if let hir::ItemKind::Struct(var_data, generics) = &item.node {
-            let fields: Vec<_> = match var_data {
-                hir::VariantData::Struct(fields, node_id) |
-                    hir::VariantData::Tuple(fields, node_id) => {fields.iter().map(|sf| (sf.ident.name.as_str().get().to_owned(), self.create_type(&sf.ty))).collect()},
-                _ => {vec![]}
-            };
-            println!("struct found: {:?}", item.name);
-            let path = self.tcx.def_path(self.map.local_def_id(item.id));
-            self.crate_data.structs.push(data::Struct {
-                name: item.name.to_string(),
-                def_path: data::GlobalDefPath::new(path.to_string_no_crate(), self.crate_data.metadata.clone()),
-                fields: fields
-            });
-        }*/
         walk_item(self, item);
     }
 
@@ -394,6 +378,5 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
 
     fn nested_visit_map<'this>(&'this mut self) -> NestedVisitorMap<'this, 'tcx> {
         NestedVisitorMap::All(self.map)
-        //NestedVisitorMap::None
     }
 }

--- a/rustql-extractor/src/visitor.rs
+++ b/rustql-extractor/src/visitor.rs
@@ -235,7 +235,7 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
                 })
             });
         } else {
-            info!("Function {} is not of kind Node::Item", def_path.to_string_no_crate());
+            debug!("Function {} is not of kind Node::Item", def_path.to_string_no_crate());
         }
         walk_fn(self, fk, fd, b, s, id);
     }
@@ -244,7 +244,6 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
         let def_id = self.map.local_def_id(ii.hir_id);
         let def_path = self.map.def_path_from_hir_id(ii.hir_id).unwrap();
         let parent = self.map.get_module_parent(ii.hir_id);
-        debug!("Impl item's {:?} parent: {:?}", ii, parent);
         let local_parent_index = self.local_modules.get(&parent).map(|x| *x).unwrap_or(0);
 
         match &ii.node {
@@ -276,8 +275,9 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
         let id = body.id();
         let owner = self.map.body_owner_def_id(id);
 
-        debug!("Found body of {:?}", owner);
+        debug!("Visiting body of {:?}", owner);
         debug!("{:?}", self.tcx.def_path(owner).to_string_no_crate());
+
         self.tcx
             .optimized_mir(owner)
             .basic_blocks()
@@ -305,8 +305,8 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
                         let krate_name= self.tcx.original_crate_name(krate).to_string();
                         let def_path = self.tcx.def_path(def_id).to_string_no_crate();
 
-                        debug!("{:?}", krate_name);
-                        debug!("{:?}", def_path);
+                        debug!("Crate name: {:?}", krate_name);
+                        debug!("Definition path: {:?}", def_path);
 
                         if let Some(ref mut f) = self.current_function {
                             // Add the calls found in the mir code to the data of the currently
@@ -319,10 +319,10 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
                                 def_path,
                             });
                         } else {
-                            //println!("ignored function call");
+                            warn!("Currently not in a function. Function call ignored.");
                         }
                     } else {
-                        //println!("ignored function call");
+                        warn!("Function doesn't match mir::Operand::Constant. Function call ignored.")
                     }
                 }
             });

--- a/rustql-extractor/src/visitor.rs
+++ b/rustql-extractor/src/visitor.rs
@@ -32,11 +32,6 @@ impl<'tcx, 'a> CrateVisitor<'tcx, 'a> {
     /// read out type information and store it in a `data::Type`
     ///
     pub fn create_type(&self, t: &hir::Ty) -> data::Type {
-        // LocalDecl
-        // use mir::args_iter()
-        //
-        // rustc::ty::TyS
-
         match &t.node {
             hir::TyKind::Path(hir::QPath::Resolved(_ty, path)) => {
                 let res = &path.res;
@@ -190,8 +185,6 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
         id: HirId,
     ) {
         let def_id = self.map.local_def_id(id);
-        //let def = self.tcx.absolute_item_path_str(def_id);
-
         let def_path = self.map.def_path_from_hir_id(id).unwrap();
 
         let parent = self.map.get_module_parent(id);
@@ -200,21 +193,12 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
         let maybe_node = self.map.find(id);
         let mir = self.tcx.optimized_mir(def_id);
 
-        //let argument_types = fd.inputs.iter().map(|t| self.create_type(t)).collect::<Vec<_>>();
         let argument_types = mir
             .args_iter()
             .map(|local| self.create_type2(&mir.local_decls[local].ty))
             .collect::<Vec<_>>();
 
-        //println!("{:?}", mir.args_iter().collect::<Vec<_>>());
-
-        //println!("{:?}", argument_types2);
-
         let return_type = self.create_type2(&mir.return_ty());
-        /*let return_type = match &fd.output {
-            hir::FunctionRetTy::DefaultReturn(_) => { println!("default return type not supported"); data::Type::Other },
-            hir::FunctionRetTy::Return(pty) => { self.create_type(&pty) }
-        };*/
 
         let mut add_function = |mut func| {
             std::mem::swap(&mut self.current_function, &mut func);
@@ -275,8 +259,6 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
     }
 
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem) {
-        //println!("visited impl item: {:?}", ii);
-
         let def_id = self.map.local_def_id(ii.hir_id);
         let def_path = self.map.def_path_from_hir_id(ii.hir_id).unwrap();
         let parent = self.map.get_module_parent(ii.hir_id);
@@ -291,10 +273,6 @@ impl<'tcx, 'a> Visitor<'tcx> for CrateVisitor<'tcx, 'a> {
                     .map(|local| self.create_type2(&mir.local_decls[local].ty))
                     .collect::<Vec<_>>();
                 let return_type = self.create_type2(&mir.return_ty());
-                /*let return_type = match &sig.decl.output {
-                    hir::FunctionRetTy::DefaultReturn(_) => { println!("default return type not supported"); data::Type::Other },
-                    hir::FunctionRetTy::Return(pty) => { self.create_type(&pty) }
-                };*/
                 let mut func = Option::Some(data::Function {
                     name: ii.ident.to_string(),
                     is_unsafe: sig.header.unsafety == rustc::hir::Unsafety::Unsafe,


### PR DESCRIPTION
This PR refactors several parts of the rustql-extractor with the goal to make the code more readable and easy to work on.

* Removes commented out (deprecated) code.
* Refactors code into functions.
* Simplifies a few parts of the code.
* Adds several comments.