### PR TITLE
Refactoring of rustql-common

### DIFF
--- a/rustql-common/src/lib.rs
+++ b/rustql-common/src/lib.rs
@@ -4,3 +4,8 @@
 
 pub mod data;
 pub mod tuples;
+
+pub const DATABASE_FILE_VARNAME: &str = "database.db";
+pub const RUSTQL_DIR_VARNAME: &str = "/.rustql/crates";
+pub const TARGET_DIR_VARNAME: &str = "EXTRACTOR_TARGET_DIR";
+pub const USE_JSON: bool = false;

--- a/rustql-common/src/tuples.rs
+++ b/rustql-common/src/tuples.rs
@@ -202,56 +202,36 @@ impl Database {
     }
 
     pub fn link_types(&mut self) {
-        for i in 0..self.types.len() {
-            let (_t_id, typ) = &self.types[i];
-            match typ {
+        for (ty_id, ty) in self.types.clone() {
+            match ty {
                 data::Type::Reference { .. } => {
-                    //let mut type_id = self.get_type(&typ);
-                    //if let None = type_id {
-                    //    let len = self::Type(self.types.len() as u64);
-                    //    type_id = Some(len);
-                    //    self.types.push((len, typ.clone()));
-                    //    println!("unknown type found during linking types");
-                    //}
-                    //let (t_id, typ) = &self.types[i];
-                    let typ = typ.clone();
-                    let added = Self::add_type_or_get(&mut self.type_finder, &mut self.types, &typ);
-                    let (t_id, _typ) = &self.types[i];
-                    self.is_reference_to.push((*t_id, added));
+                    let added = Self::add_type_or_get(&mut self.type_finder, &mut self.types, &ty);
+                    self.is_reference_to.push((ty_id, added));
                 }
                 data::Type::Tuple(types) => {
-                    for typ in types.clone() {
-                        let typ = typ.clone();
+                    for t in types.clone() {
                         let added =
-                            Self::add_type_or_get(&mut self.type_finder, &mut self.types, &typ);
-                        let (t_id, _typ) = &self.types[i];
-                        self.tuple.push((*t_id, added));
+                            Self::add_type_or_get(&mut self.type_finder, &mut self.types, &t);
+                        self.tuple.push((ty_id, added));
                     }
                 }
-                data::Type::Slice(typ) => {
-                    let typ = typ.clone();
-                    let added = Self::add_type_or_get(&mut self.type_finder, &mut self.types, &typ);
-                    let (t_id, _typ) = &self.types[i];
-                    self.slice.push((*t_id, added));
+                data::Type::Slice(slice_ty) => {
+                    let t = slice_ty.clone();
+                    let added = Self::add_type_or_get(&mut self.type_finder, &mut self.types, &t);
+                    self.slice.push((ty_id, added));
+                }
+                data::Type::Struct(ref s) => {
+                    let s = self
+                        .structs
+                        .iter()
+                        .find(|(_, s_info)| s_info.def_path == *s);
+                    if let Some((s_id, _)) = s {
+                        self.is_struct_type.push((ty_id, *s_id));
+                    } else {
+                        println!("Struct not found: {:?}", s);
+                    }
                 }
                 _ => {}
-            }
-        }
-
-        for (t_id, typ) in &self.types {
-            if let data::Type::Struct(ref s) = typ {
-                let mut found = false;
-                for (s_id, struc) in &self.structs {
-                    if struc.def_path == *s {
-                        self.is_struct_type.push((*t_id, *s_id));
-                        //println!("{:?}, {:?}", struc.def_path, *s);
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    println!("not found: {:?}", s);
-                }
             }
         }
     }

--- a/rustql-common/src/tuples.rs
+++ b/rustql-common/src/tuples.rs
@@ -105,24 +105,21 @@ impl Database {
     pub fn get_module_in_crate(&self, c_id: Crate, _mod_name: &str) -> Option<Mod> {
         self.modules_in_crates
             .iter()
-            .filter(|(_m, c)| *c == c_id)
-            .next()
-            .map(|x| x.0)
+            .find(|(_m, c)| *c == c_id)
+            .map(|(m, _c)| *m)
     }
 
     pub fn get_crate_of_function(&self, f_id: Function) -> Option<Crate> {
         let parent = self
             .functions_in_modules
             .iter()
-            .filter(|(f, _m)| *f == f_id)
-            .map(|x| x.1)
-            .next()
+            .find(|(f, _m)| *f == f_id)
+            .map(|(_f, m)| *m)
             .unwrap();
         self.modules_in_crates
             .iter()
-            .filter(|(m, _c)| *m == parent)
-            .map(|x| x.1)
-            .next()
+            .find(|(m, _c)| *m == parent)
+            .map(|(_m, c)| *c)
         /*while let Some(p) = parent {
             parent = self.modules_in_modules.iter().filter(|(m1, m2)| m1 == parent).map(|x| x.1).next();
         }*/
@@ -132,20 +129,18 @@ impl Database {
     pub fn get_function_in_crate(&self, c_id: Crate, f_def: &str) -> Option<Function> {
         self.functions
             .iter()
-            .filter(|(f_id, f)| {
+            .find(|(f_id, f)| {
                 self.get_crate_of_function(*f_id) == Some(c_id) && f.def_path == f_def
             })
-            .next()
-            .map(|x| x.0)
+            .map(|(f_id, _f)| *f_id)
     }
 
     // maybe rewrite in SQL or Datafrog
     pub fn get_module_in_module(&self, m_id: Mod, _mod_name: &str) -> Option<Mod> {
         self.modules_in_modules
             .iter()
-            .filter(|(_m, m2)| *m2 == m_id)
-            .next()
-            .map(|x| x.0)
+            .find(|(_m1, m2)| *m2 == m_id)
+            .map(|(m1, _m2)| *m1)
     }
 
     //  pub fn find_function(&self, path: &data::GlobalDefPath) -> Option<Function> {
@@ -182,9 +177,8 @@ impl Database {
     pub fn search_module(&self, name: &str) -> Option<Mod> {
         self.modules
             .iter()
-            .filter(|m| m.1.name == name)
-            .next()
-            .map(|(m, _)| *m)
+            .find(|(_id, m)| m.name == name)
+            .map(|(id, _m)| *id)
     }
 
     pub fn get_module(&self, m: Mod) -> &data::Mod {

--- a/rustql-extractor/src/main.rs
+++ b/rustql-extractor/src/main.rs
@@ -22,8 +22,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 
-const TARGET_DIR_VARNAME: &str = "EXTRACTOR_TARGET_DIR";
-const USE_JSON: bool = false;
+use rustql_common::TARGET_DIR_VARNAME;
+use rustql_common::USE_JSON;
 
 struct Callbacks;
 

--- a/rustql-linker/src/main.rs
+++ b/rustql-linker/src/main.rs
@@ -7,10 +7,10 @@ use rustql_common::data;
 use rustql_common::tuples;
 use std::error::Error;
 
-const USE_JSON: bool = false;
-const TARGET_DIR_VARNAME: &str = "EXTRACTOR_TARGET_DIR";
-const RUSTQL_DIR_VARNAME: &str = "/.rustql/crates";
-const DATABASE_FILE_VARNAME: &str = "database.db";
+use rustql_common::DATABASE_FILE_VARNAME;
+use rustql_common::RUSTQL_DIR_VARNAME;
+use rustql_common::TARGET_DIR_VARNAME;
+use rustql_common::USE_JSON;
 
 fn main() {
     env_logger::init();

--- a/rustql-linker/src/main.rs
+++ b/rustql-linker/src/main.rs
@@ -6,7 +6,6 @@ use log::{debug, error, info, warn};
 use rustql_common::data;
 use rustql_common::tuples;
 use std::error::Error;
-use std::fs::File;
 
 const USE_JSON: bool = false;
 const TARGET_DIR_VARNAME: &str = "EXTRACTOR_TARGET_DIR";
@@ -21,7 +20,7 @@ fn main() {
 }
 
 fn save_database(database: &tuples::Database, name: &str) {
-    let file = File::create(name)
+    let file = std::fs::File::create(name)
         .unwrap_or_else(|e| panic!("Could not create database {}: {}", name, e.description()));
 
     //serde_json::to_writer_pretty(file, database).expect("could not serialize to json");
@@ -190,7 +189,7 @@ fn read_crates() -> Vec<data::Crate> {
 
     for file in files {
         if let Ok(path) = file {
-            let f = File::open(path.path()).unwrap();
+            let f = std::fs::File::open(path.path()).unwrap();
             let c = if USE_JSON {
                 serde_json::from_reader(f).map_err(|_| ())
             } else {

--- a/rustql-linker/src/main.rs
+++ b/rustql-linker/src/main.rs
@@ -79,8 +79,6 @@ fn create_database() -> tuples::Database {
                 .zip(database.structs.len()..)
                 .map(|(a, b)| (tuples::Struct(b as u64), a.clone())),
         );
-        /*database.types.extend(krate.types.iter().zip(
-        ty_offset..).map(|(a, b)| (tuples::Type(b as u64), a.clone())));*/
 
         for (m, mod_id) in krate.mods.iter().zip((0..).map(module_map_to_global)) {
             let tuple = (tuples::Mod(mod_id as u64), tuples::Crate(krate_id));
@@ -110,8 +108,6 @@ fn create_database() -> tuples::Database {
     let mut fails: usize = 0;
     for (f_id, func) in &database.functions {
         for call in &func.calls {
-            //let crate_id = database.get_crate(&call.crate_ident).unwrap();
-            //let called_id = database.get_function_in_crate(crate_id, &call.def_path);
             let called_id = database
                 .function_finder
                 .get(&(call.crate_ident.clone(), call.def_path.clone()));


### PR DESCRIPTION
This PR refactors several parts of mainly rustql-common with the goal to make the code more readable and easy to work on.

- Removes commented out (deprecated) code.
- Simplifies a few parts of the code.
- Groups together constant definitions that are common among crates.
